### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "c"
+run = "gcc -o 2048 2048.c && ./2048.c"

--- a/README.md
+++ b/README.md
@@ -50,3 +50,5 @@ Contributions are very welcome. Always run the tests before committing using:
 $ ./2048 test
 All 13 tests executed successfully
 ```
+
+[![Run on Repl.it](https://repl.it/badge/github/elliota43/2048.c)](https://repl.it/github/elliota43/2048.c)


### PR DESCRIPTION
This pull request adds a badge to the `README.md` . This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).